### PR TITLE
put in tag manager

### DIFF
--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -23,6 +23,8 @@ asciidoctor:
     - coderay-css=class
     - allow-uri-read
 
+google_tag_manager: UA-140304192-1
+
 markdown: kramdown
 
 assets:


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Need the tag manager config variable for analytics to show up

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
