### PR TITLE
taking out applications stacks section from homepage

### DIFF
--- a/src/main/content/_assets/css/home.scss
+++ b/src/main/content/_assets/css/home.scss
@@ -152,8 +152,8 @@ $color-kabanero:#C43804;
 .featured_models{
     background-color: #f3f5f7;
     margin-top: 3em;
-    padding-bottom: 7em;
-    padding-top: 3em;
+    // padding-bottom: 7em;
+    // padding-top: 3em;
 }
 
 .video_description{

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -165,7 +165,7 @@ seo-title: Kabanero
 
 <!-- Featured Models -->
 <div class="neutral_background featured_models">
-    <div class="container">
+<!--     <div class="container">
         <div class="row">
             <div id="featured_models_col" class="col-md">
                 <h2 id="featured_models_title">Application Stacks</h2>
@@ -437,7 +437,7 @@ seo-title: Kabanero
                 </div>
             </div>
         </div>
-    </div>
+    </div> -->
 </div>
 
 <!-- Open Source Platform -->


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
closes: https://github.com/kabanero-io/roadmap/issues/43
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)

<img width="1655" alt="Screen Shot 2019-07-10 at 9 52 40 AM" src="https://user-images.githubusercontent.com/39460219/60974679-7e88e280-a2f8-11e9-83f8-b32980b9062f.png">