### PR TITLE
do not activate what's new until doc is filled out

### DIFF
--- a/src/main/content/_assets/js/header.js
+++ b/src/main/content/_assets/js/header.js
@@ -18,9 +18,9 @@
 
 function loadWhatsNewModal(){
     let currentVersion = String($('#modal-title').data('version'));
-
+    
     if (localStorage.didOpenWhatsNew === 'false') {
-        $('.toast').toast('show'); 
+        $('.toast').toast('show');
     }
     else if (currentVersion !== localStorage.getItem('whatsNewVersion')){
         localStorage.setItem('whatsNewVersion', currentVersion);
@@ -37,7 +37,7 @@ function loadWhatsNewModal(){
     });
 }
 
- // prevent scrolling when navbar dropdown is opened
+// prevent scrolling when navbar dropdown is opened
 $(document).ready(function(){
     $('.navbar-toggler').click(function(){
 
@@ -48,6 +48,6 @@ $(document).ready(function(){
         }
     });    
 
-    loadWhatsNewModal();
+    //loadWhatsNewModal();
 });
 

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -42,27 +42,25 @@
             </div>
         </div>
     </nav>
-</header>
-
-
-<!-- What's new Modal -->
-<div class="modal fade" tabindex="-1" id="whats-new-modal" role="dialog"
-    aria-labelledby="whatsNewModalTitle" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered whats-new-modal" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                {% assign whatsNewDoc = site.pages | where: 'name', 'whats-new.md' %}
-                <h5 data-version="{{whatsNewDoc[0].version}}" id="modal-title" class="modal-title">{{whatsNewDoc[0].title}}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                {{whatsNewDoc[0].content | markdownify}}
-            </div>
-            <div class="modal-footer">
-                <a class="col-md-5" id="modal-close-button" data-dismiss="modal">Close</a>
+    <!-- What's new Modal -->
+    {% assign whatsNewDoc = site.pages | where: 'name', 'whats-new.md' %}
+    <div class="modal fade" tabindex="-1" id="whats-new-modal" role="dialog"
+        aria-labelledby="{{whatsNewDoc[0].title}}" aria-hidden="true">
+        <div class="modal-dialog whats-new-modal" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 data-version="{{whatsNewDoc[0].version}}" id="modal-title" class="modal-title">{{whatsNewDoc[0].title}}</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    {{whatsNewDoc[0].content | markdownify}}
+                </div>
+                <div class="modal-footer">
+                    <a class="col-md-5" id="modal-close-button" data-dismiss="modal">Close</a>
+                </div>
             </div>
         </div>
     </div>
-</div>
+</header>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

do not show whats new until we update the doc for the first time

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
