### PR TITLE
open slack invite in new tab

### DIFF
--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -637,7 +637,7 @@ seo-title: Kabanero
                         <h3 class="slack-text">Chat with us on Slack</h3>
                     </div>
                     <div class="row">
-                        <a href={{site.slack_invite_url}}>
+                        <a target="_blank" href={{site.slack_invite_url}}>
                             <p class="slack-invite">Request an invite to the channel.</p>
                         </a>
                     </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

open slack invite url in a new tab
closes #116 

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
