### PR TITLE
Remove management CLI details from getting started

### DIFF
--- a/src/main/content/get-started.html
+++ b/src/main/content/get-started.html
@@ -47,22 +47,7 @@ permalink: /get-started/
         </div>
         <div class="col step-box">
             <div class="row">
-                <h4 class="col">Step 2: Install Management CLI</h4>
-            </div>
-            <div class="row">
-                <p class="col">
-                    Choose a collection, configure it, set up your pipelines, and share it with your 
-                    development team so they can start building applications.
-                </p>
-            </div>
-            <div class="col text-center">
-                <a role="button" class="btn btn-outline-dark col-md-8 kabanero-colored-button" 
-                href="/management-cli" aria-label="View instructions for installing Kabanero management CLI">{{t.common.instructions}}</a>
-            </div>
-        </div>
-        <div class="col step-box">
-            <div class="row">
-                <h4 class="col">Step 3: Install Developer Tools</h4>
+                <h4 class="col">Step 2: Install Developer Tools</h4>
             </div>
             <div class="row">
                 <p class="col">
@@ -75,6 +60,22 @@ permalink: /get-started/
                 href="/developer-tools" aria-label="View instructions for installing Kabanero developer tools">{{t.common.instructions}}</a>
             </div>
         </div>
+        <div class="col step-box">
+            <div class="row">
+                <h4 class="col">Optional Step 3: Curate your Collections</h4>
+            </div>
+            <div class="row">
+                <p class="col">
+                    Choose a collection, configure it, set up your pipelines, and share it with your 
+                    development team so they can start building applications.
+                </p>
+            </div>
+            <div class="col text-center">
+                <a role="button" class="btn btn-outline-dark col-md-8 kabanero-colored-button" 
+                href="https://github.com/kabanero-io/collections#customizing--building-the-collections-locally" target="_blank" aria-label="View instructions for installing Kabanero management CLI">{{t.common.instructions}}</a>
+            </div>
+        </div>
+        
     </div>
     <!-- Support -->
     <div class="row support-title">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
`SCREENSHOT OF NEW GETTING STARTED`
<img width="1226" alt="Screen Shot 2019-09-09 at 3 31 16 PM" src="https://user-images.githubusercontent.com/37549026/64560677-ef5b7380-d316-11e9-862f-f2a897174404.png">

