### PR TITLE
Deploy box fix

### DIFF
--- a/src/main/content/get-started.html
+++ b/src/main/content/get-started.html
@@ -60,22 +60,6 @@ permalink: /get-started/
                 href="/developer-tools" aria-label="View instructions for installing Kabanero developer tools">{{t.common.instructions}}</a>
             </div>
         </div>
-        <!-- <div class="col step-box">
-            <div class="row">
-                <h4 class="col">Optional Step 3: Curate your Collections</h4>
-            </div>
-            <div class="row">
-                <p class="col">
-                    Choose a collection, configure it, set up your pipelines, and share it with your 
-                    development team so they can start building applications.
-                </p>
-            </div>
-            <div class="col text-center">
-                <a role="button" class="btn btn-outline-dark col-md-8 kabanero-colored-button" 
-                href="https://github.com/kabanero-io/collections#customizing--building-the-collections-locally" target="_blank" aria-label="View instructions for installing Kabanero management CLI">{{t.common.instructions}}</a>
-            </div>
-        </div> -->
-        
     </div>
     <!-- Support -->
     <div class="row support-title">

--- a/src/main/content/get-started.html
+++ b/src/main/content/get-started.html
@@ -60,7 +60,7 @@ permalink: /get-started/
                 href="/developer-tools" aria-label="View instructions for installing Kabanero developer tools">{{t.common.instructions}}</a>
             </div>
         </div>
-        <div class="col step-box">
+        <!-- <div class="col step-box">
             <div class="row">
                 <h4 class="col">Optional Step 3: Curate your Collections</h4>
             </div>
@@ -74,7 +74,7 @@ permalink: /get-started/
                 <a role="button" class="btn btn-outline-dark col-md-8 kabanero-colored-button" 
                 href="https://github.com/kabanero-io/collections#customizing--building-the-collections-locally" target="_blank" aria-label="View instructions for installing Kabanero management CLI">{{t.common.instructions}}</a>
             </div>
-        </div>
+        </div> -->
         
     </div>
     <!-- Support -->

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -120,7 +120,7 @@ seo-title: Kabanero
 
                 <!-- Deploy -->
                 <div class="col open-source-platform-col">
-                    <div id="open-source-platform-deploy-box" role="button" class="open-source-platform-box" data-topic="manage" tabindex="0">
+                    <div id="open-source-platform-deploy-box" role="button" class="open-source-platform-box" data-topic="deploy" tabindex="0">
                         <p class="open-source-platform-paragraph">
                         {{t.open-source-platform.deploy.tab-name}}
                         </p>
@@ -203,7 +203,7 @@ seo-title: Kabanero
 
         <!-- Deploy detail -->
         <div class="col-md-8">
-            <div id="open-source-platform-manage-collapse" class="row collapse open-source-platform-content-box">
+            <div id="open-source-platform-deploy-collapse" class="row collapse open-source-platform-content-box">
                 <div class="row">
                     <div class="col">
                         <p class="open-source-platform-content-title">{{t.open-source-platform.deploy.tab-name}}</p>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The `deploy` open-source-platform box wasn't working correctly because it still had `manage` instead of `deploy` in its code
