### PR TITLE
Get started page: top box title placed above the box

### DIFF
--- a/src/main/content/_assets/css/get-started.scss
+++ b/src/main/content/_assets/css/get-started.scss
@@ -36,8 +36,13 @@ h4{
 .border-box{
     border: 1px solid #D8D8D8;
     padding: 50px 25px 50px 25px;
-    margin: 30px 0 60px 0;
+    margin: 30px 10px 60px 10px;
     line-height:3;
+    width:100%;
+}
+
+.getting-started-top-heading {
+    margin-top: 3em;
 }
 
 .centered{

--- a/src/main/content/get-started.html
+++ b/src/main/content/get-started.html
@@ -13,18 +13,20 @@ permalink: /get-started/
         <h1 class="col">Getting Started</h1>
         <hr>
     </div>
-    <div class="row border-box">
-        <div class="col-md-12">
+    <div class="row"> 
+        <div class="col-md-12 getting-started-top-heading">
             <h3 class="text-center">Use our development tools to explore Kabanero Public Collections</h3>
-        </div>
-        <div class="col-md-12">
-            <p class="text-center">
-                Install Codewind using your IDE or CLI on your own laptop without the need for a team environment.
-            </p>
-        </div>
-        <div class="col text-center">
-            <a role="button" class="btn btn-outline-dark kabanero-colored-button col-md-3" 
-            href="/developer-tools" aria-label="View instructions for installing Kabanero developer tools">{{t.common.instructions}}</a>
+        </div>   
+        <div class="border-box">
+            <div class="col-md-12">
+                <p class="text-center">
+                    Install Codewind using your IDE or CLI on your own laptop without the need for a team environment.
+                </p>
+            </div>
+            <div class="col text-center">
+                <a role="button" class="btn btn-outline-dark kabanero-colored-button col-md-3" 
+                href="/developer-tools" aria-label="View instructions for installing Kabanero developer tools">{{t.common.instructions}}</a>
+            </div>
         </div>
     </div>
     <div class="row text-center role-box-header">


### PR DESCRIPTION
#### What was fixed?  fixes: https://github.com/kabanero-io/kabanero-website/issues/162
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
