### PR TITLE
Footer: social media icons are in the centre

### DIFF
--- a/src/main/content/_assets/css/kabanero.scss
+++ b/src/main/content/_assets/css/kabanero.scss
@@ -396,7 +396,7 @@ footer {
         padding-top: 18px;
         overflow: hidden;
         display: inline-block;
-        padding-left: 10%;
+        padding-left: 0.3em;;
     }
 
     #footer_project {
@@ -416,6 +416,7 @@ footer {
         margin: 23px 0;
         padding-right: 10%;
         float: right;
+        padding-left: 4em;
     }
 
     .footer_round_btn {


### PR DESCRIPTION
#### What was fixed?  fixes: https://github.com/kabanero-io/kabanero-website/issues/168
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
