### PR TITLE
fix guide card height

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -18,7 +18,7 @@
 
  .guide_item {
     margin-bottom: 40px;
-    height: 215px;
+    height: 235px;
     padding-top: 22px;
     padding-left: 14px;
     padding-right: 20px;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

fixes the clock overflowing like in the screen shot below

![image](https://user-images.githubusercontent.com/3623618/64893404-f9e27980-d644-11e9-8aa2-0fb0a3b1814f.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
