### PR TITLE
info about images in guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,38 @@ Please [view our contribution guidelines](https://github.com/kabanero-io/kabaner
 Please see [Contributing to the blog](https://github.com/kabanero-io/blogs) in our Blogs repository.
 
 ## Contributing to the guides
-Each guide resides in its own repository and is dynamically pulled into the kabanero.io build process through the `scripts/build.sh` shell script. The content of the guide can be written in HTML, markdown, or AsciiDoc formats. The following front matter variables must be set:
+Each guide resides in its own repository and is dynamically pulled into the kabanero.io build process through the `scripts/build.sh` shell script. The content of the guide can be written in HTML, markdown, or AsciiDoc formats- AsciiDoc is preferred. The following front matter variables must be set:
+```
+---
+permalink: /guides/nameofguide/
+---
 - layout: guide
 - duration: `time required to complete the guide`
 - description: `one line description of the guide`
 - tags: `(optional) array of tags associated with the guide`
-- permalink: `relative url where the guide will be published`
+```
+`layout` could also be `guide-multipane` which renders that code column to show code on the side.
 
 To get started open an issue to get a repository in the kabanero-io github org created for your guide. Make sure `draft-guide-` is appended to the beginning of the repo name. `draft-` ensures it will not get published to the site. `guide-` ensures our build process will pull in the guide during build.
+
+### Images for Guides
+
+If you want to add images to your guide you can put them in your guide repository.
+
+* Image Location
+   * Create a dir in your guide repositoy called `assets` and put them in there. 
+      * These images get copied over to the sites `/img/guides/` dir during build. 
+
+* Image Naming
+   * You should include the name of your guide in the name your image to prevent image naming conflicts from other guide repositories.
+   
+* Image Reference
+   * You can reference the image in your AsciiDoc file like the following example:
+      * `image::/img/guide/name_of_your_image.png[link="/img/guide/name_of_your_image.png" alt="Your image alt text"]`
+
+### Render Guides locally
+
+While writing your guide you may want to see your updates live and rendered on the site as you develop it. You can follow [render a guide locally](CONTRIBUTING.md#render-a-guide-locally) to render your guide in a local dev environment.
 
 ## Community
 - [Kabanero on Twitter](https://twitter.com/Kabaneroio)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please [view our contribution guidelines](https://github.com/kabanero-io/kabaner
 Please see [Contributing to the blog](https://github.com/kabanero-io/blogs) in our Blogs repository.
 
 ## Contributing to the guides
-Each guide resides in its own repository and is dynamically pulled into the kabanero.io build process through the `scripts/build.sh` shell script. The content of the guide can be written in HTML, markdown, or AsciiDoc formats- AsciiDoc is preferred. The following front matter variables must be set:
+Each guide resides in its own repository and is dynamically pulled into kabanero.io via the build process. The content of the guide can be written in HTML, markdown, or AsciiDoc formats- AsciiDoc is preferred. The following front matter variables must be set:
 ```
 ---
 permalink: /guides/nameofguide/


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

add info on adding images to guides 

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
