### PR TITLE
links from resources drop down out in front

### DIFF
--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -20,18 +20,31 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav mr-auto">
                     <li class="nav-item active">
-                    <a class="nav-link" href="/try-it">Try It</a>
+                        <a class="nav-link" href="/try-it">Try It</a>
                     </li>
+                    <li class="nav-item active">
+                        <a class="nav-link" href="/docs">Docs</a>
+                    </li>
+                    <li class="nav-item active">
+                        <a class="nav-link" href="/guides">Guides</a>
+                    </li>
+                    <li class="nav-item active">
+                        <a class="nav-link" href="/blog">Blogs</a>
+                    </li>
+
+                    <!--
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="resources-dropdown" role="button" data-toggle="dropdown">
                             Resources
                         </a>
                         <div class="dropdown-menu">
-                            <a class="dropdown-item" href="/docs/">Docs</a>
-                            <a class="dropdown-item" href="/guides/" aria-label="Navigate to Kabanero guides">Guides</a>
-                            <a class="dropdown-item" href="/blog/">Blogs</a>
+                            <a class="dropdown-item" href="/docs">Docs</a>
+                            <a class="dropdown-item" href="/guides" aria-label="Navigate to Kabanero guides">Guides</a>
+                            <a class="dropdown-item" href="/blog">Blogs</a>
                         </div>
                     </li>
+                    -->
+
                     <!-- <li class="nav-item">
                     <a class="nav-link" href="/collections">Collections</a>
                     </li> -->


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Replace resources drop down on header with links that were inside it

![image](https://user-images.githubusercontent.com/3623618/65169254-2a932c00-da14-11e9-84f8-a4de4bb2b648.png)


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
