### PR TITLE
change guide layout to default

### DIFF
--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -1,5 +1,5 @@
 ---
-layout: doc
+layout: default
 css:
 - header
 - toc

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -1,5 +1,5 @@
 ---
-layout: doc
+layout: default
 title: Guides
 css:
 - guide-card


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

don't use docs layout use default now

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
