### PR TITLE
Expand click area for doc toc

### DIFF
--- a/src/main/content/_assets/css/docs.scss
+++ b/src/main/content/_assets/css/docs.scss
@@ -20,7 +20,7 @@ body{
 }
 
 .toc-item{
-    margin-bottom:15px;
+    margin-bottom:25px;
     cursor:pointer;
     & .toc-category{
         font-weight:600;
@@ -77,7 +77,7 @@ body{
     width: 15px;
     right: 15px;
     position: relative;
-    top: 5px;
+    top: 3px;
     float: left;
 }
 

--- a/src/main/content/_assets/js/docs.js
+++ b/src/main/content/_assets/js/docs.js
@@ -1,5 +1,4 @@
 $(".toc-item").click(function(){
-    console.log($(this).find(".plus-minus-icon"));
     $(this).toggleClass('open');
     $(this).find(".plus-minus-icon").attr('src') === '/img/icon_plus.png' ? $(this).find(".plus-minus-icon").attr('src', '/img/icon_minus.png') : $(this).find(".plus-minus-icon").attr('src', '/img/icon_plus.png');
 })

--- a/src/main/content/_assets/js/docs.js
+++ b/src/main/content/_assets/js/docs.js
@@ -1,12 +1,8 @@
-$(".toc-category").click(function(){
-    $(this).parent().toggleClass('open');
-    $(this).parent().find(".plus-minus-icon").attr('src') === '/img/icon_plus.png' ? $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_minus.png') : $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_plus.png');
-});
-
-$(".plus-minus-icon").click(function(){
-    $(this).parent().toggleClass('open');
-    $(this).attr('src') === '/img/icon_plus.png' ? $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_minus.png') : $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_plus.png');
-});
+$(".toc-item").click(function(){
+    console.log($(this).find(".plus-minus-icon"));
+    $(this).toggleClass('open');
+    $(this).find(".plus-minus-icon").attr('src') === '/img/icon_plus.png' ? $(this).find(".plus-minus-icon").attr('src', '/img/icon_minus.png') : $(this).find(".plus-minus-icon").attr('src', '/img/icon_plus.png');
+})
 
 $('#doc-search').keyup(function(){
     searchDocs();

--- a/src/main/content/_assets/js/docs.js
+++ b/src/main/content/_assets/js/docs.js
@@ -3,6 +3,11 @@ $(".toc-category").click(function(){
     $(this).parent().find(".plus-minus-icon").attr('src') === '/img/icon_plus.png' ? $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_minus.png') : $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_plus.png');
 });
 
+$(".plus-minus-icon").click(function(){
+    $(this).parent().toggleClass('open');
+    $(this).attr('src') === '/img/icon_plus.png' ? $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_minus.png') : $(this).parent().find(".plus-minus-icon").attr('src', '/img/icon_plus.png');
+});
+
 $('#doc-search').keyup(function(){
     searchDocs();
 });

--- a/src/main/content/_layouts/doc.html
+++ b/src/main/content/_layouts/doc.html
@@ -48,8 +48,8 @@ js:
                 </div>
                 <hr>
                 <div class="row">
-                    <nav class="sidenav">
-                        <div id="welcome-doc" class="doc-title doc-category" href="{{ introDoc[0].url }}">
+                    <nav class="sidenav col">
+                        <div id="welcome-doc" class="doc-title doc-category row" href="{{ introDoc[0].url }}">
                             <a href="{{ introDoc[0].url }}">
                                 {{introDoc[0].title}}
                             </a>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Closes #210 
The plus and minus symbols now drop down the doc categories on click on the docs page. 
![Screen Shot 2019-09-23 at 9 54 01 AM](https://user-images.githubusercontent.com/37549026/65431860-25552900-dde8-11e9-8f93-114ec0174886.png)
