### PR TITLE
Adjust spacing in docs toc

### DIFF
--- a/src/main/content/_assets/css/docs.scss
+++ b/src/main/content/_assets/css/docs.scss
@@ -36,7 +36,7 @@ body{
     }
 
     & ul > li {
-        margin-bottom:5px;
+        margin-top:6px;
     }
 
     & ul > li > a{


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Make the spaces a little larger in docs table of contents
![Screen Shot 2019-09-23 at 11 45 53 AM](https://user-images.githubusercontent.com/37549026/65441072-c5667e80-ddf7-11e9-898a-9a73dc7c629f.png)
