### PR TITLE
Float toc (scroll) fix on guides

### DIFF
--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -41,7 +41,12 @@ function disableFloatingTOC() {
 }
 
 function enableFloatingTOC() {
-    $('#toc-inner').css({'position':'fixed', 'top':'100px'});    
+    // The toc has a fixed position- this will allow it to scroll with the user and stay "snapped" at the top once the header disappears
+    var heightOfHeaderPix = 100;
+    var pixFromTop = $(window).scrollTop();
+    var newTop = heightOfHeaderPix - pixFromTop;
+    var tocTop = newTop < 0 ? 0 : newTop;
+    $('#toc-inner').css({'position':'fixed', 'top': tocTop});    
 }
 
 function calculateTOCHeight(){


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

fix toc location on scroll for guides

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
