### PR TITLE
Add dropdown menu to Slack icon in header

### DIFF
--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -50,9 +50,15 @@
                     </li> -->
                 </ul>
                 <div class="form-inline my-2 my-lg-0">
-                    <a class="float_right_section ml-3" target="_blank" href="{{site.slack_url}}">
-                    <img id="footer_slack_img" src="/img/slack_Icon.svg" class="img-fluid" alt="slack logo">
-                    </a>
+                    <div class="dropdown">
+                        <a class="float_right_section ml-3" href="#" id="header-slack-icon" data-toggle="dropdown">
+                        <img id="footer_slack_img" src="/img/slack_Icon.svg" class="img-fluid" alt="slack logo">
+                        </a>
+                        <div class="dropdown-menu" id="slack-dropdown">
+                            <a class="dropdown-item" href={{site.slack_invite_url}} target="_blank">Request an Invite</a>
+                            <a class="dropdown-item" href={{site.slack_url}} target="_blank">Go to the Channel</a>
+                        </div>
+                    </div>
                     <a class="float_right_section" target="_blank" href="{{site.stackoverflow_url}}">
                     <img id="header_stackoverflow_img" src="/img/Header_StackO.svg" class="img-fluid" alt="stackoverflow logo">
                     </a>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Closes #213 
Added a dropdown menu that toggles display when a user clicks the Slack icon.  The dropdown menu contains both the link to request an invite to the Slack channel and a link to the channel itself.

`SCREENSHOT`:
![Screen Shot 2019-09-30 at 2 11 03 PM](https://user-images.githubusercontent.com/37549026/65904430-6d49f200-e38c-11e9-9049-25045e8640df.png)

