### PR TITLE
removing languages from config so the site builds only for languages we have translation for

### DIFF
--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -48,7 +48,11 @@ exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
   - docs/templates
 
-languages: ["en", "es", "de", "fr", "it", "ja", "ko","pt-BR", "zh-CN", "zh-TW"]
+languages: ["en"]
+
+# We currently dont have translation for all these languages so we comment them out in order for the site to be built in languages we do have translation for
+# ["es", "de", "fr", "it", "ja", "ko","pt-BR", "zh-CN", "zh-TW"]
+
 default_lang: "en"
 exclude_from_localization: ["javascript", "images", "css"]
 parallel_localization: true

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -49,8 +49,7 @@ exclude:
   - docs/templates
 
 languages: ["en"]
-
-# We currently dont have translation for all these languages so we comment them out in order for the site to be built in languages we do have translation for
+# We currently dont have translation for all these languages so we comment them out.
 # ["es", "de", "fr", "it", "ja", "ko","pt-BR", "zh-CN", "zh-TW"]
 
 default_lang: "en"


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
