### PR TITLE
add draft guides env var to instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Prereqs:
    * `PAT` - Github Personal Access Token, which is required to avoid build failures due to [Github rate limiting](https://developer.github.com/v3/#rate-limiting). 
       1. **Note: For security reasons **do not** activate the "DISPLAY VALUE IN BUILD LOG" button** this is turned off by default.
       1. Head over to [Github](https://github.com/settings/tokens) and generate a personal access token (**Make sure to leave all the boxes under "Select scopes" unchecked**) then copy the generated token value and use it as the value for the environment variable. Instructions on generating a github access token can be found on the [Github help page](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line).
-      1. `JEKYLL_DRAFT_GUIDES` - This is Optional. Set this to `"true"` if you want the site to render the draft-guides
+    * `JEKYLL_DRAFT_GUIDES` - This is Optional. Set this to `"true"` if you want the site to render the draft-guides
 
    * **Optional**: you can set these environment variables to specify the repositories and branches of blogs and docs to be cloned from
       * `DOCS_GIT_URL` - Git url to clone for the docs repository (https://github.com/kabanero-io/docs.git by default)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,7 @@ Prereqs:
    * `PAT` - Github Personal Access Token, which is required to avoid build failures due to [Github rate limiting](https://developer.github.com/v3/#rate-limiting). 
       1. **Note: For security reasons **do not** activate the "DISPLAY VALUE IN BUILD LOG" button** this is turned off by default.
       1. Head over to [Github](https://github.com/settings/tokens) and generate a personal access token (**Make sure to leave all the boxes under "Select scopes" unchecked**) then copy the generated token value and use it as the value for the environment variable. Instructions on generating a github access token can be found on the [Github help page](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line).
+      1. `JEKYLL_DRAFT_GUIDES` - This is Optional. Set this to `"true"` if you want the site to render the draft-guides
 
    * **Optional**: you can set these environment variables to specify the repositories and branches of blogs and docs to be cloned from
       * `DOCS_GIT_URL` - Git url to clone for the docs repository (https://github.com/kabanero-io/docs.git by default)


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
need JEKYLL_DRAFT_GUIDES to `"true"` if you want draft guides up

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
