### PR TITLE
Show multiple authors on blog tiles on homepage

### DIFF
--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -582,7 +582,11 @@ seo-title: Kabanero
                         <div class="row container">
                             <div class="blog-header">
                                 <img src="{{ post.author_picture }}" class="blog-post-author-image" alt="Blog author picture">
-                                <a class="blog-post-author-name" href="{{ post.author_github }}">{{ post.author }}</a>
+                                <a class="blog-post-author-name" href="{{ post.author_github }}" target="_blank">{{ post.author }}</a>
+                                {% for author in post.additional_authors %}
+                                        <span>and </span>
+                                        <a class="blog-post-author-name" href="{{ author.github }}" target="_blank" rel="noopener">{{ author.name }}</a>
+                                {% endfor %}
                                 <span class="blog-post-date">on {{ post.date | date: "%B %d, %Y" }}</span>
                             </div>
                         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Closes #275 

The blog links at the bottom of the homepage only showed the first author where there were multiple authors on a blog post. This PR adds the code to show the multiple author names.

`SCREENSHOT:`
![Screen Shot 2019-10-28 at 9 29 08 AM](https://user-images.githubusercontent.com/37549026/67682515-f17c9e80-f965-11e9-86a5-e5cd02533151.png)

