### PR TITLE
show line nums if the asciidoc demands it

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -43,7 +43,6 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
   -moz-user-select: none;
   user-select: none;
   opacity: 1;
-  display: none;
 }
 .CodeRay:hover .line-numbers{
   opacity: 1;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
