### PR TITLE
removed github clone box

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -329,10 +329,6 @@ header {
     width: 100%;
 }
 
-#mobile-github-section {
-    display: none;
-}
-
 #guide-content > .sect1 {
     -webkit-box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
     -moz-box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
@@ -428,71 +424,8 @@ header {
         display: none;
     }
 
-    #github-clone-popup-container {
-        display: none;
-    }
-
     #title_row {
         margin-bottom: 30px;
-    }
-
-    #mobile-github-section {
-        display: block;
-    }
-    
-    #mobile_github_clone_popup {
-        height: 111px;
-        margin: 0 20px;
-        padding: 19px 0 0 20px;
-        background-color: #ffffff;
-        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12);
-    }
-    
-    #mobile-github-clone-popup-title {
-        font-size: 16px;
-        font-weight: 600;        
-        line-height: 1.63;
-        color: #1b1c34;
-        margin-bottom: 14px;
-
-        & > span:last-child {
-            font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
-        }
-    }
-    
-    #mobile-github-clone-popup-repo {
-        font-size: 14px;
-        line-height: 1.57;
-        color: #737373;
-        height: 44px;
-        border:1px solid $color-kabanero;
-    }
-
-    #mobile-github-clone-popup-repo > span {
-        float: left;
-        width: calc(100% - 51px);
-        white-space: nowrap;
-        overflow: auto;
-        padding: 10px;
-    }
-    
-    #mobile-github-clone-popup-copy {
-        width: 51px;
-        height: 42px;
-        background-color: $color-kabanero;
-        float: right;
-        right: 39.5px;
-        padding: 10px 18px 13px 18px;
-        text-align: center;
-    }
-
-    #mobile-github-clone-popup-copy > img {
-        width: 14px;
-        height: 16px;
-    }
-
-    #mobile-github-clone-popup-copy:hover {
-        cursor: pointer;
     }
         
     #guide-column {

--- a/src/main/content/_layouts/guide-markdown.html
+++ b/src/main/content/_layouts/guide-markdown.html
@@ -72,15 +72,6 @@ js:
                             <img src="/img/guide-duration-clock-icon-large.svg" alt="duration">
                             <span id="guide-duration">{{ page.duration }}</span>
                         </div>
-                        <div id="mobile-github-section">
-                                <div id="mobile-github-clone-popup-title"><span class="dark_green_link_light_background">Git clone</span><span> to get going right away:</span></div>
-                            <div id="mobile-github-clone-popup-repo">
-                                <span>git clone https://github.com/Kabanero-io/guide-{{page.url | replace: '/guides/', ''}}.git</span>
-                                <div id="mobile-github-clone-popup-copy" tabindex="0" aria-label="Copy the Github repository clone command">
-                                    <img src="/img/guides-copy-button-white.svg" alt="Copy Github clone command" title="Copy Github clone command">
-                                </div>
-                            </div>
-                        </div>
                     </div>
 
                     <div class="scroller-anchor"></div>

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -77,15 +77,6 @@ js:
                             <img src="/img/guide-duration-clock-icon-large.svg" alt="duration">
                             <span id="guide-duration">{{ page.duration }}</span>
                         </div>
-                        <div id="mobile-github-section">
-                            <div id="mobile-github-clone-popup-title"><span class="dark-green-link-light-background">Git clone</span><span> to get going right away:</span></div>
-                            <div id="mobile-github-clone-popup-repo">
-                                <span>git clone https://github.com/Kabanero/guide-{{page.url | replace: '/guides/guide-', ''}}.git</span>
-                                <div id="mobile-github-clone-popup-copy" tabindex="0" aria-label="Copy the Github repository clone command">
-                                    <img src="/img/guides-copy-button-white.svg" alt="Copy Github clone command" title="Copy Github clone command">
-                                </div>
-                            </div>
-                        </div>
                     </div>
 
                     <div class="scroller-anchor"></div>

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -75,15 +75,6 @@ js:
                             <img src="/img/guide-duration-clock-icon-large.svg" alt="duration">
                             <span id="guide-duration">{{ page.duration }}</span>
                         </div>
-                        <div id="mobile-github-section">
-                                <div id="mobile-github-clone-popup-title"><span class="dark_green_link_light_background">Git clone</span><span> to get going right away:</span></div>
-                            <div id="mobile-github-clone-popup-repo">
-                                <span>git clone https://github.com/Kabanero-io/guide-{{page.url | replace: '/guides/', ''}}.git</span>
-                                <div id="mobile-github-clone-popup-copy" tabindex="0" aria-label="Copy the Github repository clone command">
-                                    <img src="/img/guides-copy-button-white.svg" alt="Copy Github clone command" title="Copy Github clone command">
-                                </div>
-                            </div>
-                        </div>
                     </div>
 
                     <div class="scroller-anchor"></div>


### PR DESCRIPTION
Removed the GitHub clone box from the design, it only showed on mobile before but after a discussion in issue #278 we determined that we don't need the feature and that when we need to make some code available for cloning, the link will be put inside the guide itself.

Fixes #278 