### PR TITLE
removing extra slash from guide multipane link to git repo and adding link to edit docs 

### DIFF
--- a/src/main/content/_data/en/en.yml
+++ b/src/main/content/_data/en/en.yml
@@ -194,6 +194,7 @@ doc:
   welcome-to-docs: Welcome to Docs
   no-doc-found: No doc found
   latest: Latest
+  edit-page: Edit This Page
 
 guides:
   page-title: Guides

--- a/src/main/content/_layouts/doc.html
+++ b/src/main/content/_layouts/doc.html
@@ -120,6 +120,7 @@ js:
                 <h1 class="content-title">{{ page.title }}</h1>
                 <main aria-label="Content">
                     {{ content }}
+                    <a href="https://github.com/Kabanero-io/docs/edit/master{{page.path | remove: 'docs'}}" target="_blank" aria-label="{{t.edit-page}}">{{t.edit-page}}</a>
                 </main>
             </div>
         </div>

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -119,7 +119,7 @@ js:
                     <div id="github-clone-popup" tabindex="0">
                         <div id="github-clone-popup-title">Git clone this repo to get going right away:</div>
                         <div id="github-clone-popup-repo">
-                                git clone https://github.com/Kabanero-io/guide-{{page.url | replace: '/guides/', ''}}.git
+                                git clone https://github.com/Kabanero-io/guide-{{page.url | replace: '/guides/', '' | remove: '/'}}.git
                         </div>
                         <div id="github-clone-popup-copy" tabindex="0">
                             <img src="/img/guides-copy-button-white.svg" alt="Copy github clone command" title="Copy github clone command">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
closes: #307  #306 

![Screen Shot 2019-12-04 at 11 34 44 AM](https://user-images.githubusercontent.com/39460219/70161663-6f7d4500-168a-11ea-8193-ad59eb5425f3.png)
![Screen Shot 2019-12-04 at 11 34 27 AM](https://user-images.githubusercontent.com/39460219/70161664-6f7d4500-168a-11ea-8419-c35ac52fb50b.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
