### PR TITLE
keep bundle at 2.0.2 since 2.1.x breaks the build

### DIFF
--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,3 +1,4 @@
-echo "Installing ruby packages..."
-gem install bundler
+echo "Installing bundler and ruby packages..."
+# Install bundler 2.0.2 because 2.1.x is breaking the build
+gem install bundler -v "2.0.2"
 bundle install


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
