### PR TITLE
Changed url to the example kabanero-index.yaml to point to the latest release

### DIFF
--- a/src/main/content/cli.html
+++ b/src/main/content/cli.html
@@ -72,7 +72,7 @@ permalink: /developer/cli/
                                     URL:
 
                                     <p>
-                                        <code>https://github.com/kabanero-io/collections/releases/download/v0.1.2/kabanero-index.yaml</code>
+                                        <code>https://github.com/kabanero-io/collections/releases/latest/download/kabanero-index.yaml</code>
                                     </p>
                                 </li>
                             </ul>


### PR DESCRIPTION
… Kabanero release. 

#### What was fixed?  (Issue # or description of fix)
Updated the url to the  kabanero-index.yaml to use the latest release version. I understand that these pages are going to be updated. However, for the time being at least this gives someone (like me) a chance to pick up a current version.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
