### PR TITLE
Elaborated on Codewind description

### DIFF
--- a/src/main/content/developer.html
+++ b/src/main/content/developer.html
@@ -66,7 +66,7 @@ permalink: /developer/
         <div class="col download-detail">
             <p>
                 Codewind provides Kabanero with IDE integration and extensions to popular IDEs like VS Code,
-                Eclipse, and Eclipse Che (with more planned). This enables developers to use a workflow and IDE they
+                Eclipse, Eclipse Che, and IntelliJ. Codewind enables developers to use a workflow and IDE they
                 already know. You can rapidly iterate, debug, and performance test apps inside containers with the same environment
                 as production.
             </p>


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

closes kabanero-io/docs/issues/417

The Codewind team wanted to specify IntelliJ as an IDE we support instead of only saying "with more planned." 

@jantley-ibm not sure whom I would get to review and merge this, so I'm tagging you, thanks. 